### PR TITLE
Fixed off-by-one error when placing trailing ghost interfaces

### DIFF
--- a/src/Dimensions/1d.cpp
+++ b/src/Dimensions/1d.cpp
@@ -238,7 +238,7 @@ void Grid::updateGhosts(int it, double t){
   }
   for (int i = iRbnd; i < ntrack-1; ++i){
     Itot[i] = Itot[iRbnd-1];
-    Itot[i].x[MV] += (i-iRbnd) * Ctot[iRbnd-1].G.dx[MV];
+    Itot[i].x[MV] += (i-iRbnd+1) * Ctot[iRbnd-1].G.dx[MV];
     Itot[i].computedA();
   }
   userBoundaries(it, t); // overiding with user-specific boundary conditions


### PR DESCRIPTION
I'm implementing Monte Carlo photons that are two-way coupled to the 1d-grid. I had issues with detecting when a photon left the active grid and entered the first ghost cell on the right side.

The root of the problem was the fact that `Grid::updateGhosts`, in 1d.cpp, shifts the x-positions of the ghost interfaces by the wrong amount.